### PR TITLE
Add file attributes for Genera

### DIFF
--- a/asdf-flv.lisp
+++ b/asdf-flv.lisp
@@ -1,4 +1,4 @@
-;;; asdf-flv.lisp --- Implementation
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: NET.DIDIERVERNA.ASDF-FLV; Base: 10; -*-
 
 ;; Copyright (C) 2011, 2015 Didier Verna
 

--- a/net.didierverna.asdf-flv.asd
+++ b/net.didierverna.asdf-flv.asd
@@ -1,3 +1,4 @@
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Base: 10; -*-
 ;;; net.didierverna.asdf-flv.asd --- ASDF system definition
 
 ;; Copyright (C) 2011, 2015 Didier Verna
@@ -41,3 +42,4 @@ SET-FILE-LOCAL-VARIABLE(S)."
 	       (:file "asdf-flv")))
 
 ;;; net.didierverna.asdf-flv.asd ends here
+

--- a/package.lisp
+++ b/package.lisp
@@ -1,4 +1,4 @@
-;;; package.lisp --- Package definition
+;;;; -*- Mode: LISP; Syntax: Ansi-Common-Lisp; Package: CL-USER; Base: 10; -*-
 
 ;; Copyright (C) 2011, 2015 Didier Verna
 


### PR DESCRIPTION
Genera doesn't handle (in-package ...) the way that most people expect, but instead uses the Package file attribute to determine which package to place definitions into. This is easily fixed by adding a comment line like this:
```lisp
;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: <package-name> -*-
```
at the top of the file, with no change to the lisp code required.