### PR TITLE
Address issue 2: collision with existing ASDF:PERFORM methods.

### DIFF
--- a/net.didierverna.asdf-flv.asd
+++ b/net.didierverna.asdf-flv.asd
@@ -35,9 +35,10 @@ SET-FILE-LOCAL-VARIABLE(S)."
   :homepage "http://www.lrde.epita.fr/~didier/software/lisp/misc.php#asdf-flv"
   :source-control "https://github.com/didierverna/asdf-flv"
   :license "GNU All Permissive"
-  :version "2.2"
+  :version "2.3"
   :serial t
+  :depends-on ("closer-mop")
   :components ((:file "package")
-	       (:file "asdf-flv")))
+               (:file "asdf-flv")))
 
 ;;; net.didierverna.asdf-flv.asd ends here


### PR DESCRIPTION
Modify ASDF-FLV to add ASDF-FLV-MIXIN as superclass for ASDF:CL-SOURCE-FILE and move the existing ASDF:PERFORM :AROUND methods from ASDF:CL-SOURCE-FILE to ASDF-FLV-MIXIN.

This leaves others free to put :AROUND methods on ASDF:PERFORM.

Fixes #2